### PR TITLE
fix(ui): polish loading skeleton states

### DIFF
--- a/src/app/(auth)/auth/loading.tsx
+++ b/src/app/(auth)/auth/loading.tsx
@@ -2,20 +2,26 @@ import { Skeleton } from "~/components/ui/skeleton";
 
 export default function Loading() {
   return (
-    <div className="absolute inset-0 min-h-screen bg-[#2a2a2a] text-white flex flex-col">
-      <div className="mt-6 ml-6">
-        <Skeleton className="h-10 w-32" />
+    <div className="absolute inset-0 min-h-screen overflow-hidden bg-[#2a2a2a] text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(227,186,209,0.2),transparent_28%),radial-gradient(circle_at_bottom,rgba(255,255,255,0.06),transparent_36%)]" />
+      <div className="relative px-6 pt-6">
+        <Skeleton className="h-10 w-36 rounded-full border-white/10 bg-white/[0.05] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.12)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.06),transparent_70%)]" />
       </div>
       <div className="absolute inset-0 flex items-center justify-center px-6">
-        <div className="w-full flex flex-col items-center justify-center gap-4">
-          <div className="text-center space-y-2 mb-3">
-            <Skeleton className="h-8 w-64 mx-auto" />
-          </div>
-          <div className="w-full max-w-sm">
-            <Skeleton className="h-14 w-full rounded-lg" />
-          </div>
-          <div className="flex gap-1">
-            <Skeleton className="h-4 w-48" />
+        <div className="w-full max-w-sm rounded-[32px] border border-white/10 bg-white/[0.03] p-7 shadow-[0_36px_90px_-52px_rgba(0,0,0,0.95)] backdrop-blur-xl">
+          <div className="space-y-5">
+            <div className="space-y-3 text-center">
+              <Skeleton className="mx-auto h-8 w-56 rounded-full border-white/10 bg-white/[0.06] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.14)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.08),transparent_70%)]" />
+              <Skeleton className="mx-auto h-3.5 w-40 rounded-full border-white/10 bg-white/[0.04] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.1)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+            </div>
+            <div className="space-y-3">
+              <Skeleton className="h-14 w-full rounded-2xl border-white/10 bg-white/[0.06] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.14)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.08),transparent_70%)]" />
+              <Skeleton className="h-10 w-full rounded-2xl border-white/10 bg-white/[0.04] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.1)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+            </div>
+            <div className="space-y-2 pt-1">
+              <Skeleton className="h-3.5 w-full rounded-full border-white/10 bg-white/[0.04] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.1)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+              <Skeleton className="h-3.5 w-5/6 rounded-full border-white/10 bg-white/[0.04] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.1)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/(chat)/chat/[id]/loading.tsx
+++ b/src/app/(chat)/chat/[id]/loading.tsx
@@ -1,21 +1,5 @@
-import { Skeleton } from "~/components/ui/skeleton";
+import ChatLoadingShell from "../_components/chat-loading-shell";
 
 export default function Loading() {
-  return (
-    <div className="flex h-full w-full flex-col gap-4 p-4">
-      <div className="flex items-center gap-3">
-        <Skeleton className="h-10 w-10 rounded-full" />
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-3 w-24" />
-        </div>
-      </div>
-      <div className="flex-1 space-y-4">
-        <Skeleton className="h-20 w-3/4" />
-        <Skeleton className="h-20 w-2/3 ml-auto" />
-        <Skeleton className="h-20 w-3/4" />
-      </div>
-      <Skeleton className="h-12 w-full" />
-    </div>
-  );
+  return <ChatLoadingShell />;
 }

--- a/src/app/(chat)/chat/_components/chat-loading-shell.tsx
+++ b/src/app/(chat)/chat/_components/chat-loading-shell.tsx
@@ -1,0 +1,93 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+function MessageSkeleton({
+  align = "left",
+  width = "max-w-[44rem]",
+  lines,
+}: {
+  align?: "left" | "right";
+  width?: string;
+  lines: string[];
+}) {
+  return (
+    <div
+      className={`flex w-full ${align === "right" ? "justify-end" : "justify-start"}`}
+    >
+      <div className={`flex w-full flex-col gap-2 ${width}`}>
+        {lines.map((line, index) => (
+          <Skeleton key={`${align}-${line}-${index}`} className={line} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function ChatLoadingShell() {
+  return (
+    <div className="absolute inset-0 overflow-hidden">
+      <div
+        className="absolute inset-0 overflow-y-scroll pb-40"
+        style={{ scrollbarGutter: "stable both-edges" }}
+      >
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 pt-safe-offset-10 pb-10">
+          <div className="rounded-[24px] border border-border/60 bg-card/75 p-4 shadow-[0_24px_50px_-38px_rgba(0,0,0,0.65)] backdrop-blur-sm">
+            <div className="flex items-center gap-3">
+              <Skeleton className="size-10 rounded-2xl" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-3 w-40" />
+              </div>
+              <Skeleton className="h-9 w-24 rounded-full" />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-6">
+            <MessageSkeleton
+              lines={[
+                "h-4 w-40 rounded-full",
+                "h-5 w-full rounded-full",
+                "h-5 w-[82%] rounded-full",
+                "h-5 w-[64%] rounded-full",
+              ]}
+            />
+            <MessageSkeleton
+              align="right"
+              width="max-w-[75%]"
+              lines={[
+                "ml-auto h-10 w-full rounded-[20px]",
+                "ml-auto h-10 w-[84%] rounded-[20px]",
+              ]}
+            />
+            <MessageSkeleton
+              lines={[
+                "h-4 w-32 rounded-full",
+                "h-5 w-full rounded-full",
+                "h-5 w-[88%] rounded-full",
+                "h-5 w-[72%] rounded-full",
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="absolute bottom-0 z-10 w-full px-2">
+        <div className="relative mx-auto w-full max-w-3xl">
+          <div className="rounded-t-[22px] border border-[#404040] bg-[#2a2a2a]/95 p-3 pb-safe-offset-3 shadow-[0_-28px_60px_-36px_rgba(0,0,0,0.9)] backdrop-blur-xl">
+            <div className="space-y-3">
+              <Skeleton className="h-5 w-52 rounded-full border-white/10 bg-white/[0.06] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.12)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.06),transparent_70%)]" />
+              <Skeleton className="h-5 w-2/3 rounded-full border-white/10 bg-white/[0.04] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.1)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+            </div>
+
+            <div className="mt-5 flex items-end justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-8 w-28 rounded-full border-white/10 bg-white/[0.05] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.12)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+                <Skeleton className="h-8 w-20 rounded-full border-white/10 bg-white/[0.04] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.1)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]" />
+              </div>
+              <Skeleton className="size-8 rounded-xl border-white/10 bg-white/[0.08] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.14)_48%,transparent_72%)] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.08),transparent_70%)]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(chat)/chat/loading.tsx
+++ b/src/app/(chat)/chat/loading.tsx
@@ -1,21 +1,5 @@
-import { Skeleton } from "~/components/ui/skeleton";
+import ChatLoadingShell from "./_components/chat-loading-shell";
 
 export default function Loading() {
-  return (
-    <div className="flex h-full w-full flex-col gap-4 p-4">
-      <div className="flex items-center gap-3">
-        <Skeleton className="h-10 w-10 rounded-full" />
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-3 w-24" />
-        </div>
-      </div>
-      <div className="flex-1 space-y-4">
-        <Skeleton className="h-20 w-3/4" />
-        <Skeleton className="h-20 w-2/3 ml-auto" />
-        <Skeleton className="h-20 w-3/4" />
-      </div>
-      <Skeleton className="h-12 w-full" />
-    </div>
-  );
+  return <ChatLoadingShell />;
 }

--- a/src/app/(chat)/layout.tsx
+++ b/src/app/(chat)/layout.tsx
@@ -4,7 +4,16 @@ import AppSidebar from "./_components/sidebar";
 import { Skeleton } from "~/components/ui/skeleton";
 import {
   Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
   SidebarInset,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
   SidebarProvider,
 } from "~/components/ui/sidebar";
 import { DataStreamProvider } from "~/components/chat/data-stream/provider";
@@ -12,24 +21,56 @@ import { DataStreamProvider } from "~/components/chat/data-stream/provider";
 function SidebarSkeleton() {
   return (
     <Sidebar collapsible="offcanvas" variant="inset">
-      <div className="flex h-full flex-col">
-        <div className="flex flex-col gap-3 mx-1 p-0 pt-4">
-          <div className="h-8 flex items-center justify-center">
-            <Skeleton className="h-6 w-20" />
-          </div>
-          <div className="px-4">
-            <Skeleton className="h-9 w-full" />
-          </div>
-          <div className="mx-3 px-1 border-b border-accent-foreground/40">
-            <Skeleton className="h-10 w-full" />
+      <SidebarHeader className="mx-1 gap-3 p-0 pt-safe">
+        <div className="mt-4 flex h-8 items-center justify-center px-4">
+          <span className="text-lg font-bold text-[#e3bad1]/85">FuseIon</span>
+        </div>
+        <div className="space-y-2 px-4">
+          <Skeleton className="h-10 w-full rounded-xl" />
+          <div className="border-b border-accent-foreground/30 pb-2">
+            <Skeleton className="h-10 w-full rounded-xl" />
           </div>
         </div>
-        <div className="flex-1 px-4 py-4 space-y-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-8 w-full" />
-          ))}
+      </SidebarHeader>
+      <SidebarContent className="px-2 pb-4">
+        <SidebarGroup className="px-2 py-0">
+          <SidebarGroupLabel>
+            <Skeleton className="h-3 w-18 rounded-full" />
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {Array.from({ length: 4 }).map((_, index) => (
+                <SidebarMenuItem key={`recent-${index}`}>
+                  <SidebarMenuSkeleton />
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup className="px-2 py-0">
+          <SidebarGroupLabel>
+            <Skeleton className="h-3 w-22 rounded-full" />
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <SidebarMenuItem key={`older-${index}`}>
+                  <SidebarMenuSkeleton />
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter className="px-4 pb-4 pt-2">
+        <div className="flex items-center gap-3 rounded-2xl border border-border/60 bg-card/60 p-3">
+          <Skeleton className="size-10 rounded-2xl" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
         </div>
-      </div>
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -224,3 +224,19 @@
   padding: 1rem !important;
   border-radius: 0 !important;
 }
+
+@keyframes skeleton-shimmer {
+  0% {
+    transform: translateX(-120%);
+  }
+
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot='skeleton']::before {
+    animation: none !important;
+  }
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -2,10 +2,25 @@ import { Skeleton } from "~/components/ui/skeleton";
 
 export default function Loading() {
   return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <div className="flex flex-col items-center gap-4">
-        <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-48" />
+    <div className="relative flex min-h-screen w-full items-center justify-center overflow-hidden px-4">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(225,121,181,0.18),transparent_32%),radial-gradient(circle_at_bottom_right,rgba(255,255,255,0.08),transparent_28%)]" />
+      <div className="relative mx-auto w-full max-w-3xl">
+        <div className="mx-auto flex w-full max-w-xl flex-col gap-4 rounded-[28px] border border-border/60 bg-card/75 p-6 shadow-[0_32px_90px_-54px_rgba(0,0,0,0.7)] backdrop-blur-xl">
+          <div className="flex items-center gap-4">
+            <Skeleton className="size-12 rounded-2xl" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-3 w-44" />
+            </div>
+            <Skeleton className="h-9 w-20 rounded-full" />
+          </div>
+          <Skeleton className="h-28 w-full rounded-[24px]" />
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Skeleton className="h-20 rounded-[20px]" />
+            <Skeleton className="h-20 rounded-[20px]" />
+            <Skeleton className="h-20 rounded-[20px]" />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -4,7 +4,13 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn(
+        "relative isolate overflow-hidden rounded-[calc(var(--radius)+4px)] border border-zinc-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.96),rgba(244,244,245,0.88))] shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_18px_30px_-24px_rgba(24,24,27,0.32)]",
+        "before:absolute before:inset-0 before:translate-x-[-120%] before:animate-[skeleton-shimmer_1.8s_ease-in-out_infinite] before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.94)_48%,transparent_72%)]",
+        "after:absolute after:inset-px after:rounded-[inherit] after:bg-[linear-gradient(180deg,rgba(255,255,255,0.24),transparent_65%)]",
+        "dark:border-white/8 dark:bg-[linear-gradient(180deg,rgba(255,255,255,0.075),rgba(255,255,255,0.035))] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_24px_40px_-32px_rgba(0,0,0,0.85)] dark:before:bg-[linear-gradient(110deg,transparent_25%,rgba(255,255,255,0.14)_48%,transparent_72%)] dark:after:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent_70%)]",
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- redesign the base skeleton primitive with a surfaced shimmer treatment
- replace generic auth, root, sidebar, and chat loading screens with structured layouts
- align loader padding and max-width constraints with the real app shells

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished all loading skeletons with a new shimmer-based primitive and structured shells that mirror the real app. Improves visual consistency and perceived speed across auth, chat, and the sidebar, with reduced-motion support.

- **Refactors**
  - Rebuilt `Skeleton` with shimmer layers, light/dark styles, and a reduced-motion fallback.
  - Added `ChatLoadingShell` and used it for `/chat` and `/chat/[id]` loading routes.
  - Updated chat sidebar loader with `SidebarHeader`, `SidebarContent`, `SidebarFooter`, and `SidebarMenuSkeleton` to match the real shell.
  - Refreshed auth and root loaders with proper max-width, padding, and background treatments.
  - Added `skeleton-shimmer` keyframes in `globals.css`.

<sup>Written for commit ded65ce624ed20ce43b77bf5041f0790e804fa3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

